### PR TITLE
Create QuickELoggerObjC that can be consumed in an Objective-C project

### DIFF
--- a/IntegrationSpecs/QuickELoggerObjCIntegrationSpec.swift
+++ b/IntegrationSpecs/QuickELoggerObjCIntegrationSpec.swift
@@ -1,0 +1,150 @@
+import Quick
+import Nimble
+
+@testable import QuickELogger
+
+class QuickELoggerObjCIntegrationSpec: QuickSpec {
+    override func spec() {
+        describe("QuickELoggerObjC") {
+            var subject: QuickELoggerObjC!
+            
+            beforeSuite {
+                emptyDocumentsDirectory()
+            }
+            
+            afterSuite {
+                emptyDocumentsDirectory()
+            }
+            
+            describe("when using the default filename for the log file") {
+                beforeEach {
+                    subject = QuickELoggerObjC()
+                }
+                
+                describe("when logging a message") {
+                    describe("when a log file doesn't exist on disk") {
+                        beforeEach {
+                            subject.log(message: "Goofus", type: .error)
+                        }
+                        
+                        afterEach {
+                            emptyDocumentsDirectory()
+                        }
+                        
+                        it("is logged in a new JSON file to disk") {
+                            let logMessages = getLogMessages()
+                                                        
+                            expect(logMessages.count).to(equal(1))
+                            
+                            let logMessage = logMessages.first!
+                            
+                            expect(logMessage.id).toNot(beNil())
+                            expect(logMessage.timeStamp).toNot(beNil())
+                            
+                            expect(logMessage.type).to(equal(.error))
+                            expect(logMessage.message).to(equal("Goofus"))
+                        }
+                    }
+                    
+                    describe("when a log file already exists on disk") {
+                        beforeEach {
+                            subject.log(message: "Goofus", type: .error)
+                            subject.log(message: "Gallant", type: .info)
+                        }
+                        
+                        afterEach {
+                            emptyDocumentsDirectory()
+                        }
+                        
+                        it("is logged with the previous JSON data to disk") {
+                            let logMessages = getLogMessages()
+                                                        
+                            expect(logMessages.count).to(equal(2))
+                            
+                            let previousLogMessage = logMessages[0]
+                            
+                            expect(previousLogMessage.id).toNot(beNil())
+                            expect(previousLogMessage.timeStamp).toNot(beNil())
+                            
+                            expect(previousLogMessage.type).to(equal(.error))
+                            expect(previousLogMessage.message).to(equal("Goofus"))
+                            
+                            let newLogMessage = logMessages[1]
+                            
+                            expect(newLogMessage.id).toNot(beNil())
+                            expect(newLogMessage.timeStamp).toNot(beNil())
+                            
+                            expect(newLogMessage.type).to(equal(.info))
+                            expect(newLogMessage.message).to(equal("Gallant"))
+                        }
+                    }
+                }
+            }
+            
+            describe("when using a user specified filename for the log file") {
+                beforeEach {
+                    subject = QuickELoggerObjC(filename: "mas-tacos")
+                }
+                
+                describe("when logging a message") {
+                    describe("when a log file doesn't exist on disk") {
+                        beforeEach {
+                            subject.log(message: "Goofus", type: .error)
+                        }
+                        
+                        afterEach {
+                            emptyDocumentsDirectory()
+                        }
+                        
+                        it("is logged in a new JSON file to disk") {
+                            let logMessages = getLogMessages(filename: "mas-tacos")
+                                                        
+                            expect(logMessages.count).to(equal(1))
+                            
+                            let logMessage = logMessages.first!
+                            
+                            expect(logMessage.id).toNot(beNil())
+                            expect(logMessage.timeStamp).toNot(beNil())
+                            
+                            expect(logMessage.type).to(equal(.error))
+                            expect(logMessage.message).to(equal("Goofus"))
+                        }
+                    }
+                    
+                    describe("when a log file already exists on disk") {
+                        beforeEach {
+                            subject.log(message: "Goofus", type: .error)
+                            subject.log(message: "Gallant", type: .info)
+                        }
+                        
+                        afterEach {
+                            emptyDocumentsDirectory()
+                        }
+                        
+                        it("is logged with the previous JSON data to disk") {
+                            let logMessages = getLogMessages(filename: "mas-tacos")
+                                                        
+                            expect(logMessages.count).to(equal(2))
+                            
+                            let previousLogMessage = logMessages[0]
+                            
+                            expect(previousLogMessage.id).toNot(beNil())
+                            expect(previousLogMessage.timeStamp).toNot(beNil())
+                            
+                            expect(previousLogMessage.type).to(equal(.error))
+                            expect(previousLogMessage.message).to(equal("Goofus"))
+                            
+                            let newLogMessage = logMessages[1]
+                            
+                            expect(newLogMessage.id).toNot(beNil())
+                            expect(newLogMessage.timeStamp).toNot(beNil())
+                            
+                            expect(newLogMessage.type).to(equal(.info))
+                            expect(newLogMessage.message).to(equal("Gallant"))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/QuickELogger.xcodeproj/project.pbxproj
+++ b/QuickELogger.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		942059E82363B73D0081BE92 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 942059E62363B73D0081BE92 /* Main.storyboard */; };
 		942059EA2363B73E0081BE92 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 942059E92363B73E0081BE92 /* Assets.xcassets */; };
 		942059ED2363B73E0081BE92 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 942059EB2363B73E0081BE92 /* LaunchScreen.storyboard */; };
+		946CE535236B4309002DA985 /* QuickELoggerObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946CE534236B4309002DA985 /* QuickELoggerObjC.swift */; };
+		946CE537236B433D002DA985 /* QuickELoggerObjCIntegrationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946CE536236B433D002DA985 /* QuickELoggerObjCIntegrationSpec.swift */; };
 		946E72F42363BDF800694575 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946E72F02363BDF800694575 /* Utils.swift */; };
 		946E72F52363BDF800694575 /* QuickELogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946E72F12363BDF800694575 /* QuickELogger.swift */; };
 		946E72F62363BDF800694575 /* FoundationProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946E72F22363BDF800694575 /* FoundationProtocols.swift */; };
@@ -65,6 +67,8 @@
 		942059EE2363B73E0081BE92 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		94205A042363B9F20081BE92 /* Specs.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Specs.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		94205A082363B9F20081BE92 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		946CE534236B4309002DA985 /* QuickELoggerObjC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickELoggerObjC.swift; sourceTree = "<group>"; };
+		946CE536236B433D002DA985 /* QuickELoggerObjCIntegrationSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickELoggerObjCIntegrationSpec.swift; sourceTree = "<group>"; };
 		946E72F02363BDF800694575 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		946E72F12363BDF800694575 /* QuickELogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickELogger.swift; sourceTree = "<group>"; };
 		946E72F22363BDF800694575 /* FoundationProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationProtocols.swift; sourceTree = "<group>"; };
@@ -163,6 +167,7 @@
 				946E72F22363BDF800694575 /* FoundationProtocols.swift */,
 				946E72F12363BDF800694575 /* QuickELogger.swift */,
 				946E72F32363BDF800694575 /* QuickELoggerEngine.swift */,
+				946CE534236B4309002DA985 /* QuickELoggerObjC.swift */,
 				946E72F02363BDF800694575 /* Utils.swift */,
 			);
 			path = Source;
@@ -229,9 +234,10 @@
 		946E730E2364A99000694575 /* IntegrationSpecs */ = {
 			isa = PBXGroup;
 			children = (
-				946E73182364AC8D00694575 /* Utils */,
 				946E730F2364A99000694575 /* QuickELoggerIntegrationSpec.swift */,
+				946CE536236B433D002DA985 /* QuickELoggerObjCIntegrationSpec.swift */,
 				946E73172364A9CA00694575 /* Supporting Files */,
+				946E73182364AC8D00694575 /* Utils */,
 			);
 			path = IntegrationSpecs;
 			sourceTree = "<group>";
@@ -523,6 +529,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				946E73082363F1D800694575 /* FoundationExtensions.swift in Sources */,
+				946CE535236B4309002DA985 /* QuickELoggerObjC.swift in Sources */,
 				942059E52363B73D0081BE92 /* ViewController.swift in Sources */,
 				946E72F72363BDF800694575 /* QuickELoggerEngine.swift in Sources */,
 				946E72F62363BDF800694575 /* FoundationProtocols.swift in Sources */,
@@ -550,6 +557,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				946CE537236B433D002DA985 /* QuickELoggerObjCIntegrationSpec.swift in Sources */,
 				946E73102364A99000694575 /* QuickELoggerIntegrationSpec.swift in Sources */,
 				946E731A2364ACA800694575 /* Utils.swift in Sources */,
 			);

--- a/QuickELogger/Source/QuickELoggerObjC.swift
+++ b/QuickELogger/Source/QuickELoggerObjC.swift
@@ -1,0 +1,82 @@
+//Copyright (c) 2019 Ryan Baumbach <github@ryan.codes>
+//
+//Permission is hereby granted, free of charge, to any person obtaining
+//a copy of this software and associated documentation files (the
+//"Software"), to deal in the Software without restriction, including
+//without limitation the rights to use, copy, modify, merge, publish,
+//distribute, sublicense, and/or sell copies of the Software, and to
+//permit persons to whom the Software is furnished to do so, subject to
+//the following conditions:
+//
+//The above copyright notice and this permission notice shall be
+//included in all copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+//LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+//OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+//WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import Foundation
+
+@objc
+public enum ObjCLogType: Int {
+    case verbose
+    case info
+    case debug
+    case warn
+    case error
+}
+
+@objc
+public class QuickELoggerObjC: NSObject {
+    // MARK: - Public properties
+    
+    let engine: QuickELoggerEngine
+    
+    // MARK: - Init methods
+    
+    @objc
+    public convenience override init() {
+        self.init(filename: "QuickELogger")
+    }
+    
+    @objc
+    public init(filename: String) {
+        engine = QuickELoggerEngine(filename: filename)
+        
+        super.init()
+    }
+    
+    // MARK: - Public methods
+    
+    @objc
+    public func log(message: String, type: ObjCLogType) {
+        let transformedLogType = transformLogType(objcLogType: type)
+        
+        engine.log(message: message, type: transformedLogType, currentDate: Date())
+    }
+    
+    // MARK: - Private methods
+    
+    private func transformLogType(objcLogType: ObjCLogType) -> LogType {
+        switch objcLogType {
+        case .verbose:
+            return .verbose
+            
+        case .info:
+            return .info
+            
+        case .debug:
+            return .debug
+            
+        case .warn:
+            return .warn
+            
+        case .error:
+            return .error
+        }
+    }
+}


### PR DESCRIPTION
I've created `QuickELoggerObjC ` which can be consumed in an Objective-C project.