### PR TITLE
Add application support directory option

### DIFF
--- a/IntegrationSpecs/QuickELoggerIntegrationSpec.swift
+++ b/IntegrationSpecs/QuickELoggerIntegrationSpec.swift
@@ -168,28 +168,6 @@ class QuickELoggerIntegrationSpec: QuickSpec {
                         expect(logMessage.message).to(equal("This is temporary and will get deleted frequently"))
                     }
                 }
-
-                describe("Caches") {
-                    beforeEach {
-                        subject = QuickELogger(directory: .caches)
-
-                        subject.log(message: "This can be deleted unexpectedly", type: .info)
-                    }
-
-                    it("writes the log file to the caches directory") {
-                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .caches)
-
-                        expect(logMessages.count).to(equal(1))
-
-                        let logMessage = logMessages.first!
-
-                        expect(logMessage.id).toNot(beNil())
-                        expect(logMessage.timeStamp).toNot(beNil())
-
-                        expect(logMessage.type).to(equal(.info))
-                        expect(logMessage.message).to(equal("This can be deleted unexpectedly"))
-                    }
-                }
                 
                 describe("Library") {
                     beforeEach {
@@ -210,6 +188,28 @@ class QuickELoggerIntegrationSpec: QuickSpec {
 
                         expect(logMessage.type).to(equal(.info))
                         expect(logMessage.message).to(equal("This is the top-level directory for any files that are not user data files"))
+                    }
+                }
+
+                describe("Caches") {
+                    beforeEach {
+                        subject = QuickELogger(directory: .caches)
+
+                        subject.log(message: "This can be deleted unexpectedly", type: .info)
+                    }
+
+                    it("writes the log file to the caches directory") {
+                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .caches)
+
+                        expect(logMessages.count).to(equal(1))
+
+                        let logMessage = logMessages.first!
+
+                        expect(logMessage.id).toNot(beNil())
+                        expect(logMessage.timeStamp).toNot(beNil())
+
+                        expect(logMessage.type).to(equal(.info))
+                        expect(logMessage.message).to(equal("This can be deleted unexpectedly"))
                     }
                 }
             }

--- a/IntegrationSpecs/QuickELoggerIntegrationSpec.swift
+++ b/IntegrationSpecs/QuickELoggerIntegrationSpec.swift
@@ -212,6 +212,28 @@ class QuickELoggerIntegrationSpec: QuickSpec {
                         expect(logMessage.message).to(equal("This can be deleted unexpectedly"))
                     }
                 }
+                
+                describe("Application Support") {
+                    beforeEach {
+                        subject = QuickELogger(directory: .applicationSupport)
+
+                        subject.log(message: "This is where you should add app related data that is to be hidden from the user", type: .info)
+                    }
+
+                    it("writes the log file to the application support directory") {
+                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .applicationSupport)
+
+                        expect(logMessages.count).to(equal(1))
+
+                        let logMessage = logMessages.first!
+
+                        expect(logMessage.id).toNot(beNil())
+                        expect(logMessage.timeStamp).toNot(beNil())
+
+                        expect(logMessage.type).to(equal(.info))
+                        expect(logMessage.message).to(equal("This is where you should add app related data that is to be hidden from the user"))
+                    }
+                }
             }
         }
     }

--- a/IntegrationSpecs/QuickELoggerObjCIntegrationSpec.swift
+++ b/IntegrationSpecs/QuickELoggerObjCIntegrationSpec.swift
@@ -168,28 +168,6 @@ class QuickELoggerObjCIntegrationSpec: QuickSpec {
                         expect(logMessage.message).to(equal("This is temporary and will get deleted frequently"))
                     }
                 }
-
-                describe("Caches") {
-                    beforeEach {
-                        subject = QuickELoggerObjC(directory: .caches)
-
-                        subject.log(message: "This can be deleted unexpectedly", type: .info)
-                    }
-
-                    it("writes the log file to the caches directory") {
-                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .caches)
-
-                        expect(logMessages.count).to(equal(1))
-
-                        let logMessage = logMessages.first!
-
-                        expect(logMessage.id).toNot(beNil())
-                        expect(logMessage.timeStamp).toNot(beNil())
-
-                        expect(logMessage.type).to(equal(.info))
-                        expect(logMessage.message).to(equal("This can be deleted unexpectedly"))
-                    }
-                }
                 
                 describe("Library") {
                     beforeEach {
@@ -210,6 +188,28 @@ class QuickELoggerObjCIntegrationSpec: QuickSpec {
 
                         expect(logMessage.type).to(equal(.info))
                         expect(logMessage.message).to(equal("This is the top-level directory for any files that are not user data files"))
+                    }
+                }
+
+                describe("Caches") {
+                    beforeEach {
+                        subject = QuickELoggerObjC(directory: .caches)
+
+                        subject.log(message: "This can be deleted unexpectedly", type: .info)
+                    }
+
+                    it("writes the log file to the caches directory") {
+                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .caches)
+
+                        expect(logMessages.count).to(equal(1))
+
+                        let logMessage = logMessages.first!
+
+                        expect(logMessage.id).toNot(beNil())
+                        expect(logMessage.timeStamp).toNot(beNil())
+
+                        expect(logMessage.type).to(equal(.info))
+                        expect(logMessage.message).to(equal("This can be deleted unexpectedly"))
                     }
                 }
             }

--- a/IntegrationSpecs/Utils/FileManagerUtils.swift
+++ b/IntegrationSpecs/Utils/FileManagerUtils.swift
@@ -5,7 +5,7 @@ let directoryDict = [ Directory.documents: FileManager.default.urls(for: .docume
                       Directory.temp: FileManager.default.temporaryDirectory,
                       Directory.library: FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first!,
                       Directory.caches: FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!,
-                      Directory.applicationSupport: FileManager.default.urls(for: .applicationSupport, in: .userDomainMask).first! ]
+                      Directory.applicationSupport: FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first! ]
 
 func deleteAllTestFiles() {
     let fileManager = FileManager.default

--- a/IntegrationSpecs/Utils/FileManagerUtils.swift
+++ b/IntegrationSpecs/Utils/FileManagerUtils.swift
@@ -4,7 +4,8 @@ import Foundation
 let directoryDict = [ Directory.documents: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!,
                       Directory.temp: FileManager.default.temporaryDirectory,
                       Directory.library: FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first!,
-                      Directory.caches: FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first! ]
+                      Directory.caches: FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!,
+                      Directory.applicationSupport: FileManager.default.urls(for: .applicationSupport, in: .userDomainMask).first! ]
 
 func deleteAllTestFiles() {
     let fileManager = FileManager.default

--- a/IntegrationSpecs/Utils/FileManagerUtils.swift
+++ b/IntegrationSpecs/Utils/FileManagerUtils.swift
@@ -1,10 +1,10 @@
 import Foundation
 @testable import QuickELogger
 
-let directoryDict = [Directory.documents: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!,
-                     Directory.temp: FileManager.default.temporaryDirectory,
-                     Directory.caches: FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!,
-                     Directory.library: FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first!]
+let directoryDict = [ Directory.documents: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!,
+                      Directory.temp: FileManager.default.temporaryDirectory,
+                      Directory.library: FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first!,
+                      Directory.caches: FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first! ]
 
 func deleteAllTestFiles() {
     let fileManager = FileManager.default

--- a/IntegrationSpecs/Utils/Utils.swift
+++ b/IntegrationSpecs/Utils/Utils.swift
@@ -11,11 +11,11 @@ func getLogMessages(filename: String = "QuickELogger", directory: Directory = .d
     case .temp:
         fullPathOfJSONFile = directoryDict[.temp]!.appendingPathComponent("\(filename).json")
         
-    case .caches:
-        fullPathOfJSONFile = directoryDict[.caches]!.appendingPathComponent("\(filename).json")
-        
     case .library:
         fullPathOfJSONFile = directoryDict[.library]!.appendingPathComponent("\(filename).json")
+    
+    case .caches:
+        fullPathOfJSONFile = directoryDict[.caches]!.appendingPathComponent("\(filename).json")
     }
             
     guard let jsonData = try? Data(contentsOf: fullPathOfJSONFile, options: .alwaysMapped) else {

--- a/IntegrationSpecs/Utils/Utils.swift
+++ b/IntegrationSpecs/Utils/Utils.swift
@@ -16,6 +16,9 @@ func getLogMessages(filename: String = "QuickELogger", directory: Directory = .d
     
     case .caches:
         fullPathOfJSONFile = directoryDict[.caches]!.appendingPathComponent("\(filename).json")
+    
+    case .applicationSupport
+        fullPathOfJSONFile = directory[.applicationSupport]!.appendingPathComponent("\(filename).json")
     }
             
     guard let jsonData = try? Data(contentsOf: fullPathOfJSONFile, options: .alwaysMapped) else {

--- a/IntegrationSpecs/Utils/Utils.swift
+++ b/IntegrationSpecs/Utils/Utils.swift
@@ -17,8 +17,8 @@ func getLogMessages(filename: String = "QuickELogger", directory: Directory = .d
     case .caches:
         fullPathOfJSONFile = directoryDict[.caches]!.appendingPathComponent("\(filename).json")
     
-    case .applicationSupport
-        fullPathOfJSONFile = directory[.applicationSupport]!.appendingPathComponent("\(filename).json")
+    case .applicationSupport:
+        fullPathOfJSONFile = directoryDict[.applicationSupport]!.appendingPathComponent("\(filename).json")
     }
             
     guard let jsonData = try? Data(contentsOf: fullPathOfJSONFile, options: .alwaysMapped) else {

--- a/QuickELogger/Source/ObjC/EnumTransformationFunctions.swift
+++ b/QuickELogger/Source/ObjC/EnumTransformationFunctions.swift
@@ -29,11 +29,11 @@ func transformDirectory(objcDirectory: ObjCDirectory) -> Directory {
     case .temp:
         return .temp
         
-    case .caches:
-        return .caches
-        
     case .library:
         return .library
+        
+    case .caches:
+        return .caches
     }
 }
 

--- a/QuickELogger/Source/ObjC/EnumTransformationFunctions.swift
+++ b/QuickELogger/Source/ObjC/EnumTransformationFunctions.swift
@@ -34,6 +34,9 @@ func transformDirectory(objcDirectory: ObjCDirectory) -> Directory {
         
     case .caches:
         return .caches
+        
+    case .applicationSupport:
+        return .applicationSupport
     }
 }
 

--- a/QuickELogger/Source/ObjC/QuickELoggerObjC.swift
+++ b/QuickELogger/Source/ObjC/QuickELoggerObjC.swift
@@ -25,8 +25,8 @@ import Foundation
 public enum ObjCDirectory: Int {
     case documents
     case temp
-    case caches
     case library
+    case caches
 }
 
 @objc

--- a/QuickELogger/Source/ObjC/QuickELoggerObjC.swift
+++ b/QuickELogger/Source/ObjC/QuickELoggerObjC.swift
@@ -27,6 +27,7 @@ public enum ObjCDirectory: Int {
     case temp
     case library
     case caches
+    case applicationSupport
 }
 
 @objc

--- a/QuickELogger/Source/Swift/FoundationProtocols.swift
+++ b/QuickELogger/Source/Swift/FoundationProtocols.swift
@@ -28,6 +28,10 @@ protocol FileManagerProtocol {
 
     func urls(for directory: FileManager.SearchPathDirectory,
               in domainMask: FileManager.SearchPathDomainMask) -> [URL]
+    
+    func fileExists(atPath path: String) -> Bool
+    
+    func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey: Any]?) throws
 }
 
 extension FileManager: FileManagerProtocol { }

--- a/QuickELogger/Source/Swift/QuickELogger.swift
+++ b/QuickELogger/Source/Swift/QuickELogger.swift
@@ -26,6 +26,7 @@ public enum Directory {
     case temp
     case library
     case caches
+    case applicationSupport
 }
 
 public enum LogType: String, Equatable, Codable {

--- a/QuickELogger/Source/Swift/QuickELogger.swift
+++ b/QuickELogger/Source/Swift/QuickELogger.swift
@@ -24,8 +24,8 @@ import Foundation
 public enum Directory {
     case documents
     case temp
-    case caches
     case library
+    case caches
 }
 
 public enum LogType: String, Equatable, Codable {

--- a/QuickELogger/Source/Swift/QuickELoggerEngine.swift
+++ b/QuickELogger/Source/Swift/QuickELoggerEngine.swift
@@ -108,6 +108,9 @@ class QuickELoggerEngine: QuickELoggerEngineProtocol {
             
         case .caches:
             directoryPath = systemDirectory(.cachesDirectory)
+            
+        case .applicationSupport:
+            directoryPath = systemDirectory(.applicationSupportDirectory)
         }
                                 
         return directoryPath.appendingPathComponent(filename)

--- a/QuickELogger/Source/Swift/QuickELoggerEngine.swift
+++ b/QuickELogger/Source/Swift/QuickELoggerEngine.swift
@@ -103,11 +103,11 @@ class QuickELoggerEngine: QuickELoggerEngineProtocol {
         case .temp:
             directoryPath = fileManager.temporaryDirectory
             
-        case .caches:
-            directoryPath = systemDirectory(.cachesDirectory)
-            
         case .library:
             directoryPath = systemDirectory(.libraryDirectory)
+            
+        case .caches:
+            directoryPath = systemDirectory(.cachesDirectory)
         }
                                 
         return directoryPath.appendingPathComponent(filename)

--- a/QuickELogger/Source/Swift/QuickELoggerEngine.swift
+++ b/QuickELogger/Source/Swift/QuickELoggerEngine.swift
@@ -111,6 +111,10 @@ class QuickELoggerEngine: QuickELoggerEngineProtocol {
             
         case .applicationSupport:
             directoryPath = systemDirectory(.applicationSupportDirectory)
+            
+            if !fileManager.fileExists(atPath: directoryPath.path) {
+                try! fileManager.createDirectory(at: directoryPath, withIntermediateDirectories: false, attributes: nil)
+            }
         }
                                 
         return directoryPath.appendingPathComponent(filename)

--- a/Specs/Fakes/FakeFileManager.swift
+++ b/Specs/Fakes/FakeFileManager.swift
@@ -7,12 +7,26 @@ class FakeFileManager: FileManagerProtocol {
     var capturedSearchPathDirectory: FileManager.SearchPathDirectory?
     var capturedSearchPathDomainMask: FileManager.SearchPathDomainMask?
     
+    var capturedFileExistsPath: String?
+    
+    var capturedCreateDirectoryURL: URL?
+    var capturedCreateDirectoryCreateIntermediates: Bool?
+    var capturedCreateDirectoryAttributes: [FileAttributeKey: Any]?
+    
     // MARK: - Stubbed properties
     
     var stubbedTemporaryDirectory = URL(string: "https://temp.temp")!
     
-    var stubbedURLS = [URL(string: "https://ryan.codes")!,
-                       URL(string: "https://theaccidentalengineer.com")!]
+    var stubbedURLs: [URL] = {
+        var components = URLComponents()
+        components.scheme = "file"
+        components.host = ""
+        components.path = "/fake-directory/extra-fake-directory"
+        
+        return [components.url!, URL(string: "https://theaccidentalengineer.com")!]
+    }()
+    
+    var stubbedFileExistsPath = false
     
     // MARK: - <FileManagerProtocol>
     
@@ -25,6 +39,18 @@ class FakeFileManager: FileManagerProtocol {
         capturedSearchPathDirectory = directory
         capturedSearchPathDomainMask = domainMask
         
-        return stubbedURLS
+        return stubbedURLs
+    }
+    
+    func fileExists(atPath path: String) -> Bool {
+        capturedFileExistsPath = path
+        
+        return stubbedFileExistsPath
+    }
+    
+    func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey: Any]?) throws {
+        capturedCreateDirectoryURL = url
+        capturedCreateDirectoryCreateIntermediates = createIntermediates
+        capturedCreateDirectoryAttributes = attributes
     }
 }

--- a/Specs/QuickELoggerEngineSpec.swift
+++ b/Specs/QuickELoggerEngineSpec.swift
@@ -113,6 +113,9 @@ class QuickELoggerEngineSpec: QuickSpec {
                 }
             }
             
+            // Note: Additional information regarding the different save directories on iOS can be found here:
+            // https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html
+            
             describe("saving to different disk directories") {
                 beforeEach {
                     fakeDataUtils.shouldThrowLoadDataException = true

--- a/Specs/QuickELoggerEngineSpec.swift
+++ b/Specs/QuickELoggerEngineSpec.swift
@@ -186,6 +186,29 @@ class QuickELoggerEngineSpec: QuickSpec {
                         expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "https://ryan.codes/ItsLogLog.json")))
                     }
                 }
+                
+                describe("application support directory") {
+                    beforeEach {
+                        subject = QuickELoggerEngine(filename: "ItsLogLog",
+                                                     directory: .applicationSupport,
+                                                     fileManager: fakeFileManager,
+                                                     jsonEncoder: fakeJSONEncoder,
+                                                     jsonDecoder: fakeJSONDecoder,
+                                                     dataUtils: fakeDataUtils,
+                                                     uuid: fakeUUID)
+                        
+                        subject.log(message: "application support", type: .info, currentDate: justADate)
+                    }
+                    
+                    it("can accept log saves") {
+                        let expectedLogMessages = [LogMessage(id: "uuid-amigos-012345", timeStamp: justADate, type: .info, message: "application support")]
+                        
+                        expect(fakeJSONEncoder.capturedEncodeValue as? [LogMessage]).to(equal(expectedLogMessages))
+                        
+                        expect(fakeDataUtils.capturedWriteData).to(equal(fakeJSONEncoder.stubbedEncodeData))
+                        expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "https://ryan.codes/ItsLogLog.json")))
+                    }
+                }
             }
         }
     }

--- a/Specs/QuickELoggerEngineSpec.swift
+++ b/Specs/QuickELoggerEngineSpec.swift
@@ -70,7 +70,7 @@ class QuickELoggerEngineSpec: QuickSpec {
                         expect(fakeJSONEncoder.capturedEncodeValue as? [LogMessage]).to(equal(expectedLogMessages))
                         
                         expect(fakeDataUtils.capturedWriteData).to(equal(fakeJSONEncoder.stubbedEncodeData))
-                        expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "https://ryan.codes/ItsLogLog.json")))
+                        expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/ItsLogLog.json")))
                     }
                 }
                 
@@ -88,7 +88,7 @@ class QuickELoggerEngineSpec: QuickSpec {
                             expect(fakeJSONEncoder.capturedEncodeValue as? [LogMessage]).to(equal(expectedLogMessages))
                                                        
                             expect(fakeDataUtils.capturedWriteData).to(equal(fakeJSONEncoder.stubbedEncodeData))
-                            expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "https://ryan.codes/ItsLogLog.json")))
+                            expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/ItsLogLog.json")))
                         }
                     }
                     
@@ -107,7 +107,7 @@ class QuickELoggerEngineSpec: QuickSpec {
                             expect(fakeJSONEncoder.capturedEncodeValue as? [LogMessage]).to(equal(expectedLogMessages))
                                                        
                             expect(fakeDataUtils.capturedWriteData).to(equal(fakeJSONEncoder.stubbedEncodeData))
-                            expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "https://ryan.codes/ItsLogLog.json")))
+                            expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/ItsLogLog.json")))
                         }
                     }
                 }
@@ -160,7 +160,7 @@ class QuickELoggerEngineSpec: QuickSpec {
                         expect(fakeJSONEncoder.capturedEncodeValue as? [LogMessage]).to(equal(expectedLogMessages))
                         
                         expect(fakeDataUtils.capturedWriteData).to(equal(fakeJSONEncoder.stubbedEncodeData))
-                        expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "https://ryan.codes/ItsLogLog.json")))
+                        expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/ItsLogLog.json")))
                     }
                 }
                 
@@ -183,30 +183,70 @@ class QuickELoggerEngineSpec: QuickSpec {
                         expect(fakeJSONEncoder.capturedEncodeValue as? [LogMessage]).to(equal(expectedLogMessages))
                         
                         expect(fakeDataUtils.capturedWriteData).to(equal(fakeJSONEncoder.stubbedEncodeData))
-                        expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "https://ryan.codes/ItsLogLog.json")))
+                        expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/ItsLogLog.json")))
                     }
                 }
                 
                 describe("application support directory") {
-                    beforeEach {
-                        subject = QuickELoggerEngine(filename: "ItsLogLog",
-                                                     directory: .applicationSupport,
-                                                     fileManager: fakeFileManager,
-                                                     jsonEncoder: fakeJSONEncoder,
-                                                     jsonDecoder: fakeJSONDecoder,
-                                                     dataUtils: fakeDataUtils,
-                                                     uuid: fakeUUID)
+                    // Note: The "Library/Application Support" directory doesn't exist by default when an application is loaded.
+                    // This is why we need code to create the directory to dump our logs in if it doesn't exist.
+                    
+                    // Additional note: The apple docs say that the directory is "Application support" with a lowercase "support".
+                    // However, the FileManager API returns "Application Support" with an uppercase "Support".
+                    
+                    describe("when the application support directory doesn't exist") {
+                        beforeEach {
+                            subject = QuickELoggerEngine(filename: "ItsLogLog",
+                                                         directory: .applicationSupport,
+                                                         fileManager: fakeFileManager,
+                                                         jsonEncoder: fakeJSONEncoder,
+                                                         jsonDecoder: fakeJSONDecoder,
+                                                         dataUtils: fakeDataUtils,
+                                                         uuid: fakeUUID)
+
+                            subject.log(message: "application support", type: .info, currentDate: justADate)
+                        }
                         
-                        subject.log(message: "application support", type: .info, currentDate: justADate)
+                        it("creates the application support directory") {
+                            expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory"))
+                            expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory")))
+                            expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beFalsy())
+                            expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                        }
+                        
+                        it("can accept log saves") {
+                            let expectedLogMessages = [LogMessage(id: "uuid-amigos-012345", timeStamp: justADate, type: .info, message: "application support")]
+                            
+                            expect(fakeJSONEncoder.capturedEncodeValue as? [LogMessage]).to(equal(expectedLogMessages))
+                            
+                            expect(fakeDataUtils.capturedWriteData).to(equal(fakeJSONEncoder.stubbedEncodeData))
+                            expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/ItsLogLog.json")))
+                        }
                     }
                     
-                    it("can accept log saves") {
-                        let expectedLogMessages = [LogMessage(id: "uuid-amigos-012345", timeStamp: justADate, type: .info, message: "application support")]
-                        
-                        expect(fakeJSONEncoder.capturedEncodeValue as? [LogMessage]).to(equal(expectedLogMessages))
-                        
-                        expect(fakeDataUtils.capturedWriteData).to(equal(fakeJSONEncoder.stubbedEncodeData))
-                        expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "https://ryan.codes/ItsLogLog.json")))
+                    describe("when the application support directory exists") {
+                        beforeEach {
+                            fakeFileManager.stubbedFileExistsPath = true
+
+                            subject = QuickELoggerEngine(filename: "ItsLogLog",
+                                                         directory: .applicationSupport,
+                                                         fileManager: fakeFileManager,
+                                                         jsonEncoder: fakeJSONEncoder,
+                                                         jsonDecoder: fakeJSONDecoder,
+                                                         dataUtils: fakeDataUtils,
+                                                         uuid: fakeUUID)
+
+                            subject.log(message: "application support", type: .info, currentDate: justADate)
+                        }
+
+                        it("can accept log saves") {
+                            let expectedLogMessages = [LogMessage(id: "uuid-amigos-012345", timeStamp: justADate, type: .info, message: "application support")]
+
+                            expect(fakeJSONEncoder.capturedEncodeValue as? [LogMessage]).to(equal(expectedLogMessages))
+
+                            expect(fakeDataUtils.capturedWriteData).to(equal(fakeJSONEncoder.stubbedEncodeData))
+                            expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/ItsLogLog.json")))
+                        }
                     }
                 }
             }

--- a/Specs/QuickELoggerEngineSpec.swift
+++ b/Specs/QuickELoggerEngineSpec.swift
@@ -141,29 +141,6 @@ class QuickELoggerEngineSpec: QuickSpec {
                     }
                 }
                 
-                describe("caches directory") {
-                    beforeEach {
-                        subject = QuickELoggerEngine(filename: "ItsLogLog",
-                                                     directory: .caches,
-                                                     fileManager: fakeFileManager,
-                                                     jsonEncoder: fakeJSONEncoder,
-                                                     jsonDecoder: fakeJSONDecoder,
-                                                     dataUtils: fakeDataUtils,
-                                                     uuid: fakeUUID)
-                        
-                        subject.log(message: "caches", type: .info, currentDate: justADate)
-                    }
-                    
-                    it("can accept log saves") {
-                        let expectedLogMessages = [LogMessage(id: "uuid-amigos-012345", timeStamp: justADate, type: .info, message: "caches")]
-                        
-                        expect(fakeJSONEncoder.capturedEncodeValue as? [LogMessage]).to(equal(expectedLogMessages))
-                        
-                        expect(fakeDataUtils.capturedWriteData).to(equal(fakeJSONEncoder.stubbedEncodeData))
-                        expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "https://ryan.codes/ItsLogLog.json")))
-                    }
-                }
-                
                 describe("library directory") {
                     beforeEach {
                         subject = QuickELoggerEngine(filename: "ItsLogLog",
@@ -179,6 +156,29 @@ class QuickELoggerEngineSpec: QuickSpec {
                     
                     it("can accept log saves") {
                         let expectedLogMessages = [LogMessage(id: "uuid-amigos-012345", timeStamp: justADate, type: .info, message: "library")]
+                        
+                        expect(fakeJSONEncoder.capturedEncodeValue as? [LogMessage]).to(equal(expectedLogMessages))
+                        
+                        expect(fakeDataUtils.capturedWriteData).to(equal(fakeJSONEncoder.stubbedEncodeData))
+                        expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "https://ryan.codes/ItsLogLog.json")))
+                    }
+                }
+                
+                describe("caches directory") {
+                    beforeEach {
+                        subject = QuickELoggerEngine(filename: "ItsLogLog",
+                                                     directory: .caches,
+                                                     fileManager: fakeFileManager,
+                                                     jsonEncoder: fakeJSONEncoder,
+                                                     jsonDecoder: fakeJSONDecoder,
+                                                     dataUtils: fakeDataUtils,
+                                                     uuid: fakeUUID)
+                        
+                        subject.log(message: "caches", type: .info, currentDate: justADate)
+                    }
+                    
+                    it("can accept log saves") {
+                        let expectedLogMessages = [LogMessage(id: "uuid-amigos-012345", timeStamp: justADate, type: .info, message: "caches")]
                         
                         expect(fakeJSONEncoder.capturedEncodeValue as? [LogMessage]).to(equal(expectedLogMessages))
                         


### PR DESCRIPTION
This PR includes the the work associated to allow the saving of log files in the `/Library/Application Support` directory.  Since this directory doesn't exist by default, there is functionally to create it if it doesn't exist.

Minor refactors of some code organization has been done as well.