### PR TITLE
Add custom directory option

### DIFF
--- a/IntegrationSpecs/QuickELoggerIntegrationSpec.swift
+++ b/IntegrationSpecs/QuickELoggerIntegrationSpec.swift
@@ -234,6 +234,41 @@ class QuickELoggerIntegrationSpec: QuickSpec {
                         expect(logMessage.message).to(equal("This is where you should add app related data that is to be hidden from the user"))
                     }
                 }
+                
+                // Note: Make sure your URL is good, or else I will crash!
+                
+                describe("custom user specified path") {
+                    var customURL: URL!
+                    
+                    beforeEach {
+                        customURL = documentsDirectory()
+                        
+                        subject = QuickELogger(directory: .custom(url: customURL))
+
+                        subject.log(message: "I will crash if the custom url isn't good!!!!", type: .info)
+                    }
+                    
+                    afterEach {
+                        // Note: Since I'm creating a custom file in the Documents directory, it will get wiped out without any additional work
+                        // since deleteAllTestFiles() deletes all files from this directory
+                        
+                        deleteAllTestFiles()
+                    }
+
+                    it("writes the log file to the custom user specified directory") {
+                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .custom(url: customURL))
+
+                        expect(logMessages.count).to(equal(1))
+
+                        let logMessage = logMessages.first!
+
+                        expect(logMessage.id).toNot(beNil())
+                        expect(logMessage.timeStamp).toNot(beNil())
+
+                        expect(logMessage.type).to(equal(.info))
+                        expect(logMessage.message).to(equal("I will crash if the custom url isn't good!!!!"))
+                    }
+                }
             }
         }
     }

--- a/IntegrationSpecs/QuickELoggerObjCIntegrationSpec.swift
+++ b/IntegrationSpecs/QuickELoggerObjCIntegrationSpec.swift
@@ -212,6 +212,63 @@ class QuickELoggerObjCIntegrationSpec: QuickSpec {
                         expect(logMessage.message).to(equal("This can be deleted unexpectedly"))
                     }
                 }
+                
+                describe("Application Support") {
+                    beforeEach {
+                        subject = QuickELoggerObjC(directory: .applicationSupport)
+
+                        subject.log(message: "This is where you should add app related data that is to be hidden from the user", type: .info)
+                    }
+
+                    it("writes the log file to the application support directory") {
+                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .applicationSupport)
+
+                        expect(logMessages.count).to(equal(1))
+
+                        let logMessage = logMessages.first!
+
+                        expect(logMessage.id).toNot(beNil())
+                        expect(logMessage.timeStamp).toNot(beNil())
+
+                        expect(logMessage.type).to(equal(.info))
+                        expect(logMessage.message).to(equal("This is where you should add app related data that is to be hidden from the user"))
+                    }
+                }
+                
+                // Note: Make sure your URL is good, or else I will crash!
+                
+                describe("custom user specified path") {
+                    var customURL: URL!
+                    
+                    beforeEach {
+                        customURL = documentsDirectory()
+                        
+                        subject = QuickELoggerObjC(customDirectory: customURL)
+
+                        subject.log(message: "I will crash if the custom url isn't good!!!!", type: .info)
+                    }
+                    
+                    afterEach {
+                        // Note: Since I'm creating a custom file in the Documents directory, it will get wiped out without any additional work
+                        // since deleteAllTestFiles() deletes all files from this directory
+                        
+                        deleteAllTestFiles()
+                    }
+
+                    it("writes the log file to the custom user specified directory") {
+                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .custom(url: customURL))
+
+                        expect(logMessages.count).to(equal(1))
+
+                        let logMessage = logMessages.first!
+
+                        expect(logMessage.id).toNot(beNil())
+                        expect(logMessage.timeStamp).toNot(beNil())
+
+                        expect(logMessage.type).to(equal(.info))
+                        expect(logMessage.message).to(equal("I will crash if the custom url isn't good!!!!"))
+                    }
+                }
             }
         }
     }

--- a/IntegrationSpecs/Utils/FileManagerUtils.swift
+++ b/IntegrationSpecs/Utils/FileManagerUtils.swift
@@ -1,7 +1,11 @@
 import Foundation
 @testable import QuickELogger
 
-let directoryDict = [ Directory.documents: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!,
+func documentsDirectory() -> URL {
+    return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+}
+
+let directoryDict = [ Directory.documents: documentsDirectory(),
                       Directory.temp: FileManager.default.temporaryDirectory,
                       Directory.library: FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first!,
                       Directory.caches: FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!,

--- a/IntegrationSpecs/Utils/Utils.swift
+++ b/IntegrationSpecs/Utils/Utils.swift
@@ -19,6 +19,9 @@ func getLogMessages(filename: String = "QuickELogger", directory: Directory = .d
     
     case .applicationSupport:
         fullPathOfJSONFile = directoryDict[.applicationSupport]!.appendingPathComponent("\(filename).json")
+        
+    case .custom(let url):
+        fullPathOfJSONFile = url.appendingPathComponent("\(filename).json")
     }
             
     guard let jsonData = try? Data(contentsOf: fullPathOfJSONFile, options: .alwaysMapped) else {

--- a/QuickELogger/AppCode/ViewController.swift
+++ b/QuickELogger/AppCode/ViewController.swift
@@ -4,7 +4,14 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        let doxDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        
         print("Dox dir")
-        print(FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!)
+        print(doxDir)
+        
+        let bundleDir = doxDir.deletingLastPathComponent()
+        
+        print("Bundle dir")
+        print(bundleDir)
     }
 }

--- a/QuickELogger/Source/ObjC/QuickELoggerObjC.swift
+++ b/QuickELogger/Source/ObjC/QuickELoggerObjC.swift
@@ -71,6 +71,18 @@ public class QuickELoggerObjC: NSObject {
         super.init()
     }
     
+    @objc
+    public convenience init(customDirectory: URL) {
+        self.init(filename: "QuickELogger", customDirectory: customDirectory)
+    }
+    
+    @objc
+    public init(filename: String, customDirectory: URL) {
+        engine = QuickELoggerEngine(filename: filename, directory: .custom(url: customDirectory))
+        
+        super.init()
+    }
+    
     // MARK: - Public methods
     
     @objc

--- a/QuickELogger/Source/Swift/FoundationExtensions.swift
+++ b/QuickELogger/Source/Swift/FoundationExtensions.swift
@@ -21,6 +21,8 @@
 
 import Foundation
 
+// MARK: - JSONEncoder.DateEncodingStrategy
+
 extension JSONEncoder.DateEncodingStrategy: Equatable {
     // MARK: - <Equatable>
     
@@ -28,6 +30,8 @@ extension JSONEncoder.DateEncodingStrategy: Equatable {
         return "\(lhs)" == "\(rhs)"
     }
 }
+
+// MARK: - JSONDecoder.DataDecodingStrategy
 
 extension JSONDecoder.DataDecodingStrategy: Equatable {
     // MARK: - <Equatable>

--- a/QuickELogger/Source/Swift/QuickELogger.swift
+++ b/QuickELogger/Source/Swift/QuickELogger.swift
@@ -21,15 +21,16 @@
 
 import Foundation
 
-public enum Directory {
+public enum Directory: Equatable, Hashable {
     case documents
     case temp
     case library
     case caches
     case applicationSupport
+    case custom(url: URL)
 }
 
-public enum LogType: String, Equatable, Codable {
+public enum LogType: String, Equatable, Hashable, Codable {
     case verbose
     case info
     case debug

--- a/QuickELogger/Source/Swift/QuickELoggerEngine.swift
+++ b/QuickELogger/Source/Swift/QuickELoggerEngine.swift
@@ -103,6 +103,10 @@ class QuickELoggerEngine: QuickELoggerEngineProtocol {
     private func saveLogMessages(messages: [LogMessage]) {
         let encodedJSONData = try! jsonEncoder.encode(messages)
         
-        try! dataUtils.write(data: encodedJSONData, toPath: jsonFilePath())
+        do {
+            try dataUtils.write(data: encodedJSONData, toPath: jsonFilePath())
+        } catch {
+            preconditionFailure("Unable to save messages json to file path: \(jsonFilePath())")
+        }
     }
 }

--- a/Specs/FileUtilsSpec.swift
+++ b/Specs/FileUtilsSpec.swift
@@ -109,6 +109,54 @@ class FileUtilsSpec: QuickSpec {
                         }
                     }
                 }
+                
+                describe("when building custom user specified url") {
+                    var customURL: URL!
+                    
+                    beforeEach {
+                        customURL = URL(string: "file:///whocares")!
+                    }
+                    
+                    describe("when the custom user specified directory doesn't exist") {
+                        beforeEach {
+                            url = subject.buildFullFileURL(directory: .custom(url: customURL), filename: "Goofus.json")
+                        }
+                        
+                        it("creates the application support directory") {
+                            expect(fakeFileManager.capturedFileExistsPath).to(equal("/whocares"))
+                            expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///whocares")))
+                            expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beFalsy())
+                            expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                        }
+                        
+                        it("builds the correct URL") {
+                            expect(fakeFileManager.capturedFileExistsPath).to(equal("/whocares"))
+                            expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///whocares")!))
+                            expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beFalsy())
+                            expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                            
+                            expect(url).to(equal(URL(string: "file:///whocares/Goofus.json")!))
+                        }
+                    }
+                    
+                    describe("when the custom user specified directory exists") {
+                        beforeEach {
+                            fakeFileManager.stubbedFileExistsPath = true
+                            
+                            url = subject.buildFullFileURL(directory: .custom(url: customURL), filename: "Goofus.json")
+                        }
+                        
+                        it("builds the correct URL") {
+                            expect(url).to(equal(URL(string: "file:///whocares/Goofus.json")!))
+                        }
+                        
+                        it("can accept log saves") {
+                            expect(fakeFileManager.capturedFileExistsPath).to(equal("/whocares"))
+                            
+                            expect(url).to(equal(URL(string: "file:///whocares/Goofus.json")!))
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Add `custom` directory option in Swift and Objective-C loggers:

### Swift

```swift
public enum Directory: Equatable, Hashable {
    case documents
    case temp
    case library
    case caches
    case applicationSupport
    case custom(url: URL)
}
```

### Objective-C

```swift
@objc
public convenience init(customDirectory: URL) { }
    
@objc
public init(filename: String, customDirectory: URL) { }
```

Note: There isn't any sanity checking with the custom URLs provided.  This is on the responsibility of the consumer of this framework to verify the save URL is good.