### PR TITLE
Allow custom standard dir selection

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,6 +4,8 @@ disabled_rules:
 
 line_length: 150
 
+cyclomatic_complexity: 12
+
 identifier_name:
   excluded:
     - id

--- a/IntegrationSpecs/QuickELoggerIntegrationSpec.swift
+++ b/IntegrationSpecs/QuickELoggerIntegrationSpec.swift
@@ -8,12 +8,18 @@ class QuickELoggerIntegrationSpec: QuickSpec {
         describe("QuickELogger") {
             var subject: QuickELogger!
             
+            // Mas cleanup...
+            
             beforeSuite {                
-                deleteAllTestFiles()
+                deleteTestArtifacts()
+            }
+            
+            afterEach {
+                deleteTestArtifacts()
             }
             
             afterSuite {
-                deleteAllTestFiles()
+                deleteTestArtifacts()
             }
             
             describe("when using the default filename for the log file") {
@@ -27,13 +33,9 @@ class QuickELoggerIntegrationSpec: QuickSpec {
                             subject.log(message: "Goofus", type: .error)
                         }
                         
-                        afterEach {
-                            deleteAllTestFiles()
-                        }
-                        
                         it("is logged in a new JSON file to disk") {
                             let logMessages = getLogMessages()
-                                                        
+                            
                             expect(logMessages.count).to(equal(1))
                             
                             let logMessage = logMessages.first!
@@ -52,13 +54,9 @@ class QuickELoggerIntegrationSpec: QuickSpec {
                             subject.log(message: "Gallant", type: .info)
                         }
                         
-                        afterEach {
-                            deleteAllTestFiles()
-                        }
-                        
                         it("is logged with the previous JSON data to disk") {
                             let logMessages = getLogMessages()
-                                                        
+                            
                             expect(logMessages.count).to(equal(2))
                             
                             let previousLogMessage = logMessages[0]
@@ -92,13 +90,9 @@ class QuickELoggerIntegrationSpec: QuickSpec {
                             subject.log(message: "Goofus", type: .error)
                         }
                         
-                        afterEach {
-                            deleteAllTestFiles()
-                        }
-                        
                         it("is logged in a new JSON file to disk") {
                             let logMessages = getLogMessages(filename: "mas-tacos")
-                                                        
+                            
                             expect(logMessages.count).to(equal(1))
                             
                             let logMessage = logMessages.first!
@@ -116,14 +110,10 @@ class QuickELoggerIntegrationSpec: QuickSpec {
                             subject.log(message: "Goofus", type: .error)
                             subject.log(message: "Gallant", type: .info)
                         }
-                        
-                        afterEach {
-                            deleteAllTestFiles()
-                        }
-                        
+
                         it("is logged with the previous JSON data to disk") {
                             let logMessages = getLogMessages(filename: "mas-tacos")
-                                                        
+                            
                             expect(logMessages.count).to(equal(2))
                             
                             let previousLogMessage = logMessages[0]
@@ -149,97 +139,207 @@ class QuickELoggerIntegrationSpec: QuickSpec {
             describe("writing to other directories besides the root Documents directory") {
                 describe("Documents/somethingElse/dude/") {
                     beforeEach {
-                        subject = QuickELogger(, directory: .documents(path: "somethingElse/"))
+                        subject = QuickELogger(directory: .documents(path: "somethingElse/dude/"))
+                        
+                        subject.log(message: "Dox", type: .info)
                     }
                     
-                    subject.log(message: "This is temporary and will get deleted frequently", type: .info)
+                    it("writes the log file to the /Documents/somethingElse/dude/ directory") {
+                        let logMessages = getLogMessages(directory: .documents(path: "somethingElse/dude/"))
+                        
+                        expect(logMessages.count).to(equal(1))
+                        
+                        let logMessage = logMessages.first!
+                        
+                        expect(logMessage.id).toNot(beNil())
+                        expect(logMessage.timeStamp).toNot(beNil())
+                        
+                        expect(logMessage.type).to(equal(.info))
+                        expect(logMessage.message).to(equal("Dox"))
+                    }
                 }
                 
                 describe("tmp") {
-                    beforeEach {
-                        subject = QuickELogger(directory: .temp)
-
-                        subject.log(message: "This is temporary and will get deleted frequently", type: .info)
+                    describe("when an additional path is given") {
+                        beforeEach {
+                            subject = QuickELogger(directory: .temp(path: "extra-temp/folder"))
+                            
+                            subject.log(message: "This is temporary and will get deleted frequently", type: .info)
+                        }
+                        
+                        it("writes the log file in the additional path directory") {
+                            let logMessages = getLogMessages(directory: .temp(path: "extra-temp/folder"))
+                            
+                            expect(logMessages.count).to(equal(1))
+                            
+                            let logMessage = logMessages.first!
+                            
+                            expect(logMessage.id).toNot(beNil())
+                            expect(logMessage.timeStamp).toNot(beNil())
+                            
+                            expect(logMessage.type).to(equal(.info))
+                            expect(logMessage.message).to(equal("This is temporary and will get deleted frequently"))
+                        }
                     }
-
-                    it("writes the log file to the temp directory") {
-                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .temp)
-
-                        expect(logMessages.count).to(equal(1))
-
-                        let logMessage = logMessages.first!
-
-                        expect(logMessage.id).toNot(beNil())
-                        expect(logMessage.timeStamp).toNot(beNil())
-
-                        expect(logMessage.type).to(equal(.info))
-                        expect(logMessage.message).to(equal("This is temporary and will get deleted frequently"))
+                    
+                    describe("when NO additional path is given") {
+                        beforeEach {
+                            subject = QuickELogger(directory: .temp())
+                            
+                            subject.log(message: "This is temporary and will get deleted frequently", type: .info)
+                        }
+                        
+                        it("writes the log file to the temp directory") {
+                            let logMessages = getLogMessages(directory: .temp())
+                            
+                            expect(logMessages.count).to(equal(1))
+                            
+                            let logMessage = logMessages.first!
+                            
+                            expect(logMessage.id).toNot(beNil())
+                            expect(logMessage.timeStamp).toNot(beNil())
+                            
+                            expect(logMessage.type).to(equal(.info))
+                            expect(logMessage.message).to(equal("This is temporary and will get deleted frequently"))
+                        }
                     }
                 }
                 
                 describe("Library") {
-                    beforeEach {
-                        subject = QuickELogger(directory: .library)
-
-                        subject.log(message: "This is the top-level directory for any files that are not user data files", type: .info)
+                    describe("when an additional path is given") {
+                        beforeEach {
+                            subject = QuickELogger(directory: .library(path: "extra-library/folder"))
+                            
+                            subject.log(message: "This is the top-level directory for any files that are not user data files", type: .info)
+                        }
+                        
+                        it("writes the log file in the additional path directory") {
+                            let logMessages = getLogMessages(directory: .library(path: "extra-library/folder"))
+                            
+                            expect(logMessages.count).to(equal(1))
+                            
+                            let logMessage = logMessages.first!
+                            
+                            expect(logMessage.id).toNot(beNil())
+                            expect(logMessage.timeStamp).toNot(beNil())
+                            
+                            expect(logMessage.type).to(equal(.info))
+                            expect(logMessage.message).to(equal("This is the top-level directory for any files that are not user data files"))
+                        }
                     }
-
-                    it("writes the log file to the library directory") {
-                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .library)
-
-                        expect(logMessages.count).to(equal(1))
-
-                        let logMessage = logMessages.first!
-
-                        expect(logMessage.id).toNot(beNil())
-                        expect(logMessage.timeStamp).toNot(beNil())
-
-                        expect(logMessage.type).to(equal(.info))
-                        expect(logMessage.message).to(equal("This is the top-level directory for any files that are not user data files"))
+                    
+                    describe("when NO additional path is given") {
+                        beforeEach {
+                            subject = QuickELogger(directory: .library())
+                            
+                            subject.log(message: "This is the top-level directory for any files that are not user data files", type: .info)
+                        }
+                        
+                        it("writes the log file to the library directory") {
+                            let logMessages = getLogMessages(directory: .library())
+                            
+                            expect(logMessages.count).to(equal(1))
+                            
+                            let logMessage = logMessages.first!
+                            
+                            expect(logMessage.id).toNot(beNil())
+                            expect(logMessage.timeStamp).toNot(beNil())
+                            
+                            expect(logMessage.type).to(equal(.info))
+                            expect(logMessage.message).to(equal("This is the top-level directory for any files that are not user data files"))
+                        }
                     }
                 }
-
+                
                 describe("Caches") {
-                    beforeEach {
-                        subject = QuickELogger(directory: .caches)
-
-                        subject.log(message: "This can be deleted unexpectedly", type: .info)
+                    describe("when an additional path is given") {
+                        beforeEach {
+                            subject = QuickELogger(directory: .caches(path: "extra-caches/folder"))
+                            
+                            subject.log(message: "This can be deleted unexpectedly", type: .info)
+                        }
+                        
+                        it("writes the log file in the additional path directory") {
+                            let logMessages = getLogMessages(directory: .caches(path: "extra-caches/folder"))
+                            
+                            expect(logMessages.count).to(equal(1))
+                            
+                            let logMessage = logMessages.first!
+                            
+                            expect(logMessage.id).toNot(beNil())
+                            expect(logMessage.timeStamp).toNot(beNil())
+                            
+                            expect(logMessage.type).to(equal(.info))
+                            expect(logMessage.message).to(equal("This can be deleted unexpectedly"))
+                        }
                     }
-
-                    it("writes the log file to the caches directory") {
-                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .caches)
-
-                        expect(logMessages.count).to(equal(1))
-
-                        let logMessage = logMessages.first!
-
-                        expect(logMessage.id).toNot(beNil())
-                        expect(logMessage.timeStamp).toNot(beNil())
-
-                        expect(logMessage.type).to(equal(.info))
-                        expect(logMessage.message).to(equal("This can be deleted unexpectedly"))
+                    
+                    describe("when NO additional path is given") {
+                        beforeEach {
+                            subject = QuickELogger(directory: .caches())
+                            
+                            subject.log(message: "This can be deleted unexpectedly", type: .info)
+                        }
+                        
+                        it("writes the log file to the caches directory") {
+                            let logMessages = getLogMessages(directory: .caches())
+                            
+                            expect(logMessages.count).to(equal(1))
+                            
+                            let logMessage = logMessages.first!
+                            
+                            expect(logMessage.id).toNot(beNil())
+                            expect(logMessage.timeStamp).toNot(beNil())
+                            
+                            expect(logMessage.type).to(equal(.info))
+                            expect(logMessage.message).to(equal("This can be deleted unexpectedly"))
+                        }
                     }
                 }
                 
                 describe("Application Support") {
-                    beforeEach {
-                        subject = QuickELogger(directory: .applicationSupport)
-
-                        subject.log(message: "This is where you should add app related data that is to be hidden from the user", type: .info)
+                    describe("when an additional path is given") {
+                        beforeEach {
+                            subject = QuickELogger(directory: .applicationSupport(path: "extra-application-support/folder"))
+                            
+                            subject.log(message: "This is where you should add app related data that is to be hidden from the user", type: .info)
+                        }
+                        
+                        it("writes the log file in the additional path directory") {
+                            let logMessages = getLogMessages(directory: .applicationSupport(path: "extra-application-support/folder"))
+                            
+                            expect(logMessages.count).to(equal(1))
+                            
+                            let logMessage = logMessages.first!
+                            
+                            expect(logMessage.id).toNot(beNil())
+                            expect(logMessage.timeStamp).toNot(beNil())
+                            
+                            expect(logMessage.type).to(equal(.info))
+                            expect(logMessage.message).to(equal("This is where you should add app related data that is to be hidden from the user"))
+                        }
                     }
 
-                    it("writes the log file to the application support directory") {
-                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .applicationSupport)
+                    describe("when NO additional path is given") {
+                        beforeEach {
+                            subject = QuickELogger(directory: .applicationSupport())
 
-                        expect(logMessages.count).to(equal(1))
+                            subject.log(message: "This is where you should add app related data that is to be hidden from the user", type: .info)
+                        }
 
-                        let logMessage = logMessages.first!
+                        it("writes the log file to the application support directory") {
+                            let logMessages = getLogMessages(directory: .applicationSupport())
 
-                        expect(logMessage.id).toNot(beNil())
-                        expect(logMessage.timeStamp).toNot(beNil())
+                            expect(logMessages.count).to(equal(1))
 
-                        expect(logMessage.type).to(equal(.info))
-                        expect(logMessage.message).to(equal("This is where you should add app related data that is to be hidden from the user"))
+                            let logMessage = logMessages.first!
+
+                            expect(logMessage.id).toNot(beNil())
+                            expect(logMessage.timeStamp).toNot(beNil())
+
+                            expect(logMessage.type).to(equal(.info))
+                            expect(logMessage.message).to(equal("This is where you should add app related data that is to be hidden from the user"))
+                        }
                     }
                 }
                 
@@ -252,27 +352,20 @@ class QuickELoggerIntegrationSpec: QuickSpec {
                         customURL = documentsDirectory()
                         
                         subject = QuickELogger(directory: .custom(url: customURL))
-
-                        subject.log(message: "I will crash if the custom url isn't good!!!!", type: .info)
-                    }
-                    
-                    afterEach {
-                        // Note: Since I'm creating a custom file in the Documents directory, it will get wiped out without any additional work
-                        // since deleteAllTestFiles() deletes all files from this directory
                         
-                        deleteAllTestFiles()
+                        subject.log(message: "I will crash if the custom url isn't good!!!!", type: .info)
                     }
 
                     it("writes the log file to the custom user specified directory") {
-                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .custom(url: customURL))
-
+                        let logMessages = getLogMessages(directory: .custom(url: customURL))
+                        
                         expect(logMessages.count).to(equal(1))
-
+                        
                         let logMessage = logMessages.first!
-
+                        
                         expect(logMessage.id).toNot(beNil())
                         expect(logMessage.timeStamp).toNot(beNil())
-
+                        
                         expect(logMessage.type).to(equal(.info))
                         expect(logMessage.message).to(equal("I will crash if the custom url isn't good!!!!"))
                     }

--- a/IntegrationSpecs/QuickELoggerIntegrationSpec.swift
+++ b/IntegrationSpecs/QuickELoggerIntegrationSpec.swift
@@ -146,7 +146,15 @@ class QuickELoggerIntegrationSpec: QuickSpec {
                 }
             }
             
-            describe("writing to other directories besides the Documents directory") {
+            describe("writing to other directories besides the root Documents directory") {
+                describe("Documents/somethingElse/dude/") {
+                    beforeEach {
+                        subject = QuickELogger(, directory: .documents(path: "somethingElse/"))
+                    }
+                    
+                    subject.log(message: "This is temporary and will get deleted frequently", type: .info)
+                }
+                
                 describe("tmp") {
                     beforeEach {
                         subject = QuickELogger(directory: .temp)

--- a/IntegrationSpecs/QuickELoggerObjCIntegrationSpec.swift
+++ b/IntegrationSpecs/QuickELoggerObjCIntegrationSpec.swift
@@ -9,11 +9,15 @@ class QuickELoggerObjCIntegrationSpec: QuickSpec {
             var subject: QuickELoggerObjC!
             
             beforeSuite {
-                deleteAllTestFiles()
+                deleteTestArtifacts()
+            }
+            
+            afterEach {
+                deleteTestArtifacts()
             }
             
             afterSuite {
-                deleteAllTestFiles()
+                deleteTestArtifacts()
             }
             
             describe("when using the default filename for the log file") {
@@ -25,10 +29,6 @@ class QuickELoggerObjCIntegrationSpec: QuickSpec {
                     describe("when a log file doesn't exist on disk") {
                         beforeEach {
                             subject.log(message: "Goofus", type: .error)
-                        }
-                        
-                        afterEach {
-                            deleteAllTestFiles()
                         }
                         
                         it("is logged in a new JSON file to disk") {
@@ -50,10 +50,6 @@ class QuickELoggerObjCIntegrationSpec: QuickSpec {
                         beforeEach {
                             subject.log(message: "Goofus", type: .error)
                             subject.log(message: "Gallant", type: .info)
-                        }
-                        
-                        afterEach {
-                            deleteAllTestFiles()
                         }
                         
                         it("is logged with the previous JSON data to disk") {
@@ -80,7 +76,7 @@ class QuickELoggerObjCIntegrationSpec: QuickSpec {
                     }
                 }
             }
-            
+                        
             describe("when using a user specified filename for the log file") {
                 beforeEach {
                     subject = QuickELoggerObjC(filename: "mas-tacos")
@@ -145,17 +141,19 @@ class QuickELoggerObjCIntegrationSpec: QuickSpec {
                     }
                 }
             }
-            
+                         
             describe("writing to other directories besides the Documents directory") {
                 describe("tmp") {
                     beforeEach {
-                        subject = QuickELoggerObjC(directory: .temp)
+                        let directoryInfo = ObjCDirectoryInfo(directory: .temp, additionalPath: "extra-temp/folder")
+                        
+                        subject = QuickELoggerObjC(directoryInfo: directoryInfo)
 
                         subject.log(message: "This is temporary and will get deleted frequently", type: .info)
                     }
 
                     it("writes the log file to the temp directory") {
-                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .temp)
+                        let logMessages = getLogMessages(directory: .temp(path: "extra-temp/folder"))
 
                         expect(logMessages.count).to(equal(1))
 
@@ -171,13 +169,15 @@ class QuickELoggerObjCIntegrationSpec: QuickSpec {
                 
                 describe("Library") {
                     beforeEach {
-                        subject = QuickELoggerObjC(directory: .library)
+                        let directoryInfo = ObjCDirectoryInfo(directory: .library, additionalPath: "extra-library/folder")
+
+                        subject = QuickELoggerObjC(directoryInfo: directoryInfo)
 
                         subject.log(message: "This is the top-level directory for any files that are not user data files", type: .info)
                     }
 
                     it("writes the log file to the library directory") {
-                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .library)
+                        let logMessages = getLogMessages(directory: .library(path: "extra-library/folder"))
 
                         expect(logMessages.count).to(equal(1))
 
@@ -193,13 +193,15 @@ class QuickELoggerObjCIntegrationSpec: QuickSpec {
 
                 describe("Caches") {
                     beforeEach {
-                        subject = QuickELoggerObjC(directory: .caches)
+                        let directoryInfo = ObjCDirectoryInfo(directory: .caches, additionalPath: "extra-caches/folder")
+
+                        subject = QuickELoggerObjC(directoryInfo: directoryInfo)
 
                         subject.log(message: "This can be deleted unexpectedly", type: .info)
                     }
 
                     it("writes the log file to the caches directory") {
-                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .caches)
+                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .caches(path: "extra-caches/folder"))
 
                         expect(logMessages.count).to(equal(1))
 
@@ -215,13 +217,15 @@ class QuickELoggerObjCIntegrationSpec: QuickSpec {
                 
                 describe("Application Support") {
                     beforeEach {
-                        subject = QuickELoggerObjC(directory: .applicationSupport)
+                        let directoryInfo = ObjCDirectoryInfo(directory: .applicationSupport, additionalPath: "extra-application-support/folder")
+
+                        subject = QuickELoggerObjC(directoryInfo: directoryInfo)
 
                         subject.log(message: "This is where you should add app related data that is to be hidden from the user", type: .info)
                     }
 
                     it("writes the log file to the application support directory") {
-                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .applicationSupport)
+                        let logMessages = getLogMessages(filename: "QuickELogger", directory: .applicationSupport(path: "extra-application-support/folder"))
 
                         expect(logMessages.count).to(equal(1))
 
@@ -243,16 +247,9 @@ class QuickELoggerObjCIntegrationSpec: QuickSpec {
                     beforeEach {
                         customURL = documentsDirectory()
                         
-                        subject = QuickELoggerObjC(customDirectory: customURL)
+                        subject = QuickELoggerObjC(customURL: customURL)
 
                         subject.log(message: "I will crash if the custom url isn't good!!!!", type: .info)
-                    }
-                    
-                    afterEach {
-                        // Note: Since I'm creating a custom file in the Documents directory, it will get wiped out without any additional work
-                        // since deleteAllTestFiles() deletes all files from this directory
-                        
-                        deleteAllTestFiles()
                     }
 
                     it("writes the log file to the custom user specified directory") {

--- a/IntegrationSpecs/Utils/FileManagerUtils.swift
+++ b/IntegrationSpecs/Utils/FileManagerUtils.swift
@@ -5,11 +5,16 @@ func documentsDirectory() -> URL {
     return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
 }
 
-let directoryDict = [ Directory.documents: documentsDirectory(),
-                      Directory.temp: FileManager.default.temporaryDirectory,
-                      Directory.library: FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first!,
-                      Directory.caches: FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!,
-                      Directory.applicationSupport: FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first! ]
+let directoryDict = [ Directory.documents(): documentsDirectory(),
+                      Directory.temp(): FileManager.default.temporaryDirectory,
+                      Directory.library(): FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first!,
+                      Directory.caches(): FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!,
+                      Directory.applicationSupport(): FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first! ]
+
+func deleteTestArtifacts() {
+    deleteAllTestFiles()
+    deleteAllTestDirectories()
+}
 
 func deleteAllTestFiles() {
     let fileManager = FileManager.default
@@ -26,13 +31,41 @@ func deleteAllTestFiles() {
         let files = allFilePathsDirectory.filter { filePath in
             return !isFilePathStringADirectory(filePath: directory.path + "/" + filePath)
         }
-        
+
         guard files.count != 0 else {
             return
         }
         
         files.forEach { documentPath in
             try! fileManager.removeItem(atPath: directory.path + "/" + documentPath)
+        }
+    }
+}
+
+func deleteAllTestDirectories() {
+    let fileManager = FileManager.default
+    
+    directoryDict.forEach { directoryKey, directoryValue in
+        guard var allFilePathsDirectory = try? fileManager.contentsOfDirectory(atPath: directoryValue.path) else {
+            return
+        }
+        
+        guard allFilePathsDirectory.count != 0 else {
+            return
+        }
+        
+        // The library directory has a bunch of system directories, let's not touch those...
+        
+        if directoryKey == .library() {
+            allFilePathsDirectory = allFilePathsDirectory.filter { filePath in
+                let librarySystemDirs = ["Preferences", "SplashBoard", "Caches", "Saved Application State"]
+                
+                return !librarySystemDirs.contains(filePath)
+            }
+        }
+        
+        allFilePathsDirectory.forEach { documentPath in
+            try! fileManager.removeItem(atPath: directoryValue.path + "/" + documentPath)
         }
     }
 }

--- a/IntegrationSpecs/Utils/Utils.swift
+++ b/IntegrationSpecs/Utils/Utils.swift
@@ -1,29 +1,12 @@
 import Foundation
 @testable import QuickELogger
 
-func getLogMessages(filename: String = "QuickELogger", directory: Directory = .documents) -> [LogMessage] {
-    var fullPathOfJSONFile: URL
+func getLogMessages(filename: String = "QuickELogger", directory: Directory = .documents()) -> [LogMessage] {    
+    let fullFilename = filename + ".json"
     
-    switch directory {
-    case .documents:
-        fullPathOfJSONFile = directoryDict[.documents]!.appendingPathComponent("\(filename).json")
-        
-    case .temp:
-        fullPathOfJSONFile = directoryDict[.temp]!.appendingPathComponent("\(filename).json")
-        
-    case .library:
-        fullPathOfJSONFile = directoryDict[.library]!.appendingPathComponent("\(filename).json")
-    
-    case .caches:
-        fullPathOfJSONFile = directoryDict[.caches]!.appendingPathComponent("\(filename).json")
-    
-    case .applicationSupport:
-        fullPathOfJSONFile = directoryDict[.applicationSupport]!.appendingPathComponent("\(filename).json")
-        
-    case .custom(let url):
-        fullPathOfJSONFile = url.appendingPathComponent("\(filename).json")
-    }
-            
+    let fullPathOfJSONFile = FileUtils().buildFullFileURL(directory: directory,
+                                                          filename: fullFilename)
+                
     guard let jsonData = try? Data(contentsOf: fullPathOfJSONFile, options: .alwaysMapped) else {
         return []
     }

--- a/QuickELogger.podspec
+++ b/QuickELogger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name                  = 'QuickELogger'
-  spec.version               = '0.1.3'
+  spec.version               = '0.2.0'
   spec.summary               = 'A quick and simple way to log messages to disk on your iPhone or iPad app'
   spec.homepage              = 'https://github.com/rbaumbach/Quick-E-Logger'
   spec.license               = { :type => 'MIT', :file => 'MIT-LICENSE.txt' }

--- a/QuickELogger/Source/ObjC/EnumTransformationFunctions.swift
+++ b/QuickELogger/Source/ObjC/EnumTransformationFunctions.swift
@@ -21,22 +21,22 @@
 
 import Foundation
 
-func transformDirectory(objcDirectory: ObjCDirectory) -> Directory {
-    switch objcDirectory {
+func transformDirectory(objcDirectoryInfo: ObjCDirectoryInfo) -> Directory {
+    switch objcDirectoryInfo.directory {
     case .documents:
-        return .documents
+        return .documents(path: objcDirectoryInfo.additionalPath)
         
     case .temp:
-        return .temp
+        return .temp(path: objcDirectoryInfo.additionalPath)
         
     case .library:
-        return .library
+        return .library(path: objcDirectoryInfo.additionalPath)
         
     case .caches:
-        return .caches
+        return .caches(path: objcDirectoryInfo.additionalPath)
         
     case .applicationSupport:
-        return .applicationSupport
+        return .applicationSupport(path: objcDirectoryInfo.additionalPath)
     }
 }
 

--- a/QuickELogger/Source/ObjC/QuickELoggerObjC.swift
+++ b/QuickELogger/Source/ObjC/QuickELoggerObjC.swift
@@ -72,6 +72,13 @@ public class QuickELoggerObjC: NSObject {
     }
     
     @objc
+    public convenience init(filename: String) {
+        let defaultDirectoryInfo = ObjCDirectoryInfo(directory: .documents, additionalPath: nil)
+        
+        self.init(filename: filename, directoryInfo: defaultDirectoryInfo)
+    }
+    
+    @objc
     public convenience init(directoryInfo: ObjCDirectoryInfo) {
         self.init(filename: "QuickELogger", directoryInfo: directoryInfo)
     }

--- a/QuickELogger/Source/ObjC/QuickELoggerObjC.swift
+++ b/QuickELogger/Source/ObjC/QuickELoggerObjC.swift
@@ -62,7 +62,7 @@ public class QuickELoggerObjC: NSObject {
     
     let engine: QuickELoggerEngine
     
-    // MARK: - Init methods
+    // MARK: - Convenience init methods
     
     @objc
     public convenience override init() {
@@ -84,10 +84,24 @@ public class QuickELoggerObjC: NSObject {
     }
     
     @objc
+    public convenience init(customURL: URL) {
+        self.init(filename: "QuickELogger", customURL: customURL)
+    }
+    
+    // MARK: - Init methods
+    
+    @objc
     public init(filename: String, directoryInfo: ObjCDirectoryInfo) {
         let transformedDirectory = transformDirectory(objcDirectoryInfo: directoryInfo)
 
         engine = QuickELoggerEngine(filename: filename, directory: transformedDirectory)
+
+        super.init()
+    }
+    
+    @objc
+    public init(filename: String, customURL: URL) {
+        engine = QuickELoggerEngine(filename: filename, directory: .custom(url: customURL))
 
         super.init()
     }

--- a/QuickELogger/Source/ObjC/QuickELoggerObjC.swift
+++ b/QuickELogger/Source/ObjC/QuickELoggerObjC.swift
@@ -40,6 +40,23 @@ public enum ObjCLogType: Int {
 }
 
 @objc
+public class ObjCDirectoryInfo: NSObject {
+    @objc
+    public var directory: ObjCDirectory = .documents
+    
+    @objc
+    public var additionalPath: String?
+    
+    @objc
+    public init(directory: ObjCDirectory, additionalPath: String?) {
+        self.directory = directory
+        self.additionalPath = additionalPath
+        
+        super.init()
+    }
+}
+
+@objc
 public class QuickELoggerObjC: NSObject {
     // MARK: - Public properties
     
@@ -49,37 +66,22 @@ public class QuickELoggerObjC: NSObject {
     
     @objc
     public convenience override init() {
-        self.init(filename: "QuickELogger", directory: .documents)
-    }
-    
-    @objc
-    public convenience init(filename: String) {
-        self.init(filename: filename, directory: .documents)
-    }
-    
-    @objc
-    public convenience init(directory: ObjCDirectory) {
-        self.init(filename: "QuickELogger", directory: directory)
-    }
-    
-    @objc
-    public init(filename: String, directory: ObjCDirectory) {
-        let transformedDirectory = transformDirectory(objcDirectory: directory)
+        let defaultDirectoryInfo = ObjCDirectoryInfo(directory: .documents, additionalPath: nil)
         
+        self.init(filename: "QuickELogger", directoryInfo: defaultDirectoryInfo)
+    }
+    
+    @objc
+    public convenience init(directoryInfo: ObjCDirectoryInfo) {
+        self.init(filename: "QuickELogger", directoryInfo: directoryInfo)
+    }
+    
+    @objc
+    public init(filename: String, directoryInfo: ObjCDirectoryInfo) {
+        let transformedDirectory = transformDirectory(objcDirectoryInfo: directoryInfo)
+
         engine = QuickELoggerEngine(filename: filename, directory: transformedDirectory)
-        
-        super.init()
-    }
-    
-    @objc
-    public convenience init(customDirectory: URL) {
-        self.init(filename: "QuickELogger", customDirectory: customDirectory)
-    }
-    
-    @objc
-    public init(filename: String, customDirectory: URL) {
-        engine = QuickELoggerEngine(filename: filename, directory: .custom(url: customDirectory))
-        
+
         super.init()
     }
     

--- a/QuickELogger/Source/Swift/QuickELogger.swift
+++ b/QuickELogger/Source/Swift/QuickELogger.swift
@@ -22,11 +22,11 @@
 import Foundation
 
 public enum Directory: Equatable, Hashable {
-    case documents
-    case temp
-    case library
-    case caches
-    case applicationSupport
+    case documents(path: String? = nil)
+    case temp(path: String? = nil)
+    case library(path: String? = nil)
+    case caches(path: String? = nil)
+    case applicationSupport(path: String? = nil)
     case custom(url: URL)
 }
 
@@ -54,7 +54,7 @@ public class QuickELogger: NSObject, QuickELoggerProtocol {
     
     // MARK: - Init methods
     
-    public init(filename: String = "QuickELogger", directory: Directory = .documents) {
+    public init(filename: String = "QuickELogger", directory: Directory = .documents()) {
         self.filename = filename
         self.directory = directory
         

--- a/QuickELogger/Source/Swift/Utils.swift
+++ b/QuickELogger/Source/Swift/Utils.swift
@@ -61,20 +61,46 @@ class FileUtils: FileUtilsProtocol {
         var directoryPath: URL
 
         switch directory {
-        case .documents:
-            directoryPath = systemDirectory(.documentDirectory)
+        case .documents(let path):
+            if let path = path {
+                directoryPath = systemDirectory(.documentDirectory).appendingPathComponent(path)
+                
+                createDirectoryIfNoneExists(directoryPath: directoryPath)
+            } else {
+                directoryPath = systemDirectory(.documentDirectory)
+            }
+        case .temp(let path):
+            if let path = path {
+                directoryPath = fileManager.temporaryDirectory.appendingPathComponent(path)
+                
+                createDirectoryIfNoneExists(directoryPath: directoryPath)
+            } else {
+                directoryPath = fileManager.temporaryDirectory
+            }
+        case .library(let path):
+            if let path = path {
+                directoryPath = systemDirectory(.libraryDirectory).appendingPathComponent(path)
+                
+                createDirectoryIfNoneExists(directoryPath: directoryPath)
+            } else {
+                directoryPath = systemDirectory(.libraryDirectory)
+            }
 
-        case .temp:
-            directoryPath = fileManager.temporaryDirectory
+        case .caches(let path):
+            if let path = path {
+                directoryPath = systemDirectory(.cachesDirectory).appendingPathComponent(path)
+                
+                createDirectoryIfNoneExists(directoryPath: directoryPath)
+            } else {
+                directoryPath = systemDirectory(.cachesDirectory)
+            }
 
-        case .library:
-            directoryPath = systemDirectory(.libraryDirectory)
-
-        case .caches:
-            directoryPath = systemDirectory(.cachesDirectory)
-
-        case .applicationSupport:
-            directoryPath = systemDirectory(.applicationSupportDirectory)
+        case .applicationSupport(let path):
+            if let path = path {
+                directoryPath = systemDirectory(.applicationSupportDirectory).appendingPathComponent(path)
+            } else {
+                directoryPath = systemDirectory(.applicationSupportDirectory)
+            }
 
             createDirectoryIfNoneExists(directoryPath: directoryPath)
 
@@ -92,12 +118,12 @@ class FileUtils: FileUtilsProtocol {
     private func systemDirectory(_ directory: FileManager.SearchPathDirectory) -> URL {
         return fileManager.urls(for: directory, in: .userDomainMask).first!
     }
-
+        
     private func createDirectoryIfNoneExists(directoryPath: URL) {
         if !fileManager.fileExists(atPath: directoryPath.path) {
             do {
                 try fileManager.createDirectory(at: directoryPath,
-                                                withIntermediateDirectories: false,
+                                                withIntermediateDirectories: true,
                                                 attributes: nil)
             } catch {
                 preconditionFailure("Unable to create directory: \(directoryPath)")

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The directory structure can be customized fit in the following standard iOS dire
 * `/Library/Caches`
 * `/Library/Application Support`
 
-using the `init(directory:)` initializer.
+using the `init(directory:)` initializer.  In addition to being able to specify a different system directory, you can also specify a path inside that system directory using and optional path in the `Directory` enum.
 
 They can also be customized using the `init(filename:directory:)` initializer as well.
 

--- a/Specs/FileUtilsSpec.swift
+++ b/Specs/FileUtilsSpec.swift
@@ -23,89 +23,285 @@ class FileUtilsSpec: QuickSpec {
                 var url: URL!
                 
                 describe("when building /Documents directory URL") {
-                    beforeEach {
-                        url = subject.buildFullFileURL(directory: .documents, filename: "Goofus.json")
+                    describe("when an additional path is given") {
+                        describe("when the additional path directory in documents doesn't exist") {
+                            beforeEach {
+                                url = subject.buildFullFileURL(directory: .documents(path: "abc/123/"), filename: "Goofus.json")
+                            }
+                            
+                            it("creates the the additional path directory in documents") {
+                                expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory/abc/123"))
+                                expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/abc/123")))
+                                expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beTruthy())
+                                expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                            }
+                            
+                            it("builds the correct URL") {
+                                expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory/abc/123"))
+                                expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/abc/123")!))
+                                expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beTruthy())
+                                expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                                
+                                expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/abc/123/Goofus.json")!))
+                            }
+                        }
+                        
+                        describe("when the additional path directory in documents exists") {
+                            beforeEach {
+                                fakeFileManager.stubbedFileExistsPath = true
+                                
+                                url = subject.buildFullFileURL(directory: .documents(), filename: "Goofus.json")
+                            }
+                            
+                            it("builds the correct URL") {
+                                expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                            }
+                        }
                     }
                     
-                    it("builds the correct URL") {
-                        expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                    describe("when NO additional path is given") {
+                        beforeEach {
+                            url = subject.buildFullFileURL(directory: .documents(), filename: "Goofus.json")
+                        }
+                        
+                        it("builds the correct URL") {
+                            expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                        }
                     }
                 }
                 
                 describe("when building /tmp directory URL") {
-                    beforeEach {
-                        url = subject.buildFullFileURL(directory: .temp, filename: "Goofus.json")
+                    describe("when an additional path is given") {
+                        describe("when the additional path directory in tmp doesn't exist") {
+                            beforeEach {
+                                url = subject.buildFullFileURL(directory: .temp(path: "abc/123/"), filename: "Goofus.json")
+                            }
+                            
+                            it("creates the the additional path directory in temp") {
+                                expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-temp-directory/abc/123"))
+                                expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///fake-temp-directory/abc/123")))
+                                expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beTruthy())
+                                expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                            }
+                            
+                            it("builds the correct URL") {
+                                expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-temp-directory/abc/123"))
+                                expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///fake-temp-directory/abc/123")!))
+                                expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beTruthy())
+                                expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                                
+                                expect(url).to(equal(URL(string: "file:///fake-temp-directory/abc/123/Goofus.json")!))
+                            }
+                        }
+                        
+                        describe("when the additional path directory in tmp exists") {
+                            beforeEach {
+                                fakeFileManager.stubbedFileExistsPath = true
+                                
+                                url = subject.buildFullFileURL(directory: .temp(), filename: "Goofus.json")
+                            }
+                            
+                            it("builds the correct URL") {
+                                expect(url).to(equal(URL(string: "file:///fake-temp-directory/Goofus.json")!))
+                            }
+                        }
                     }
                     
-                    it("builds the correct URL") {
-                        expect(url).to(equal(URL(string: "file:///fake-temp-directory/Goofus.json")!))
+                    describe("when NO additional path is given") {
+                        beforeEach {
+                            url = subject.buildFullFileURL(directory: .documents(), filename: "Goofus.json")
+                        }
+                        
+                        it("builds the correct URL") {
+                            expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                        }
                     }
                 }
                 
                 describe("when building /Library directory URL") {
-                    beforeEach {
-                        url = subject.buildFullFileURL(directory: .library, filename: "Goofus.json")
+                    describe("when an additional path is given") {
+                        describe("when the additional path directory in library doesn't exist") {
+                            beforeEach {
+                                url = subject.buildFullFileURL(directory: .library(path: "abc/123/"), filename: "Goofus.json")
+                            }
+                            
+                            it("creates the the additional path directory in library") {
+                                expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory/abc/123"))
+                                expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/abc/123")))
+                                expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beTruthy())
+                                expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                            }
+                            
+                            it("builds the correct URL") {
+                                expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory/abc/123"))
+                                expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/abc/123")!))
+                                expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beTruthy())
+                                expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                                
+                                expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/abc/123/Goofus.json")!))
+                            }
+                        }
+                        
+                        describe("when the additional path directory in library exists") {
+                            beforeEach {
+                                fakeFileManager.stubbedFileExistsPath = true
+                                
+                                url = subject.buildFullFileURL(directory: .library(), filename: "Goofus.json")
+                            }
+                            
+                            it("builds the correct URL") {
+                                expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                            }
+                        }
                     }
                     
-                    it("builds the correct URL") {
-                        expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                    describe("when NO additional path is given") {
+                        beforeEach {
+                            url = subject.buildFullFileURL(directory: .library(), filename: "Goofus.json")
+                        }
+                        
+                        it("builds the correct URL") {
+                            expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                        }
                     }
                 }
                 
                 describe("when building /Library/Caches directory URL") {
-                    beforeEach {
-                        url = subject.buildFullFileURL(directory: .caches, filename: "Goofus.json")
+                    describe("when an additional path is given") {
+                        describe("when the additional path directory in documents doesn't exist") {
+                            beforeEach {
+                                url = subject.buildFullFileURL(directory: .caches(path: "abc/123/"), filename: "Goofus.json")
+                            }
+                            
+                            it("creates the the additional path directory in caches") {
+                                expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory/abc/123"))
+                                expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/abc/123")))
+                                expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beTruthy())
+                                expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                            }
+                            
+                            it("builds the correct URL") {
+                                expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory/abc/123"))
+                                expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/abc/123")!))
+                                expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beTruthy())
+                                expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                                
+                                expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/abc/123/Goofus.json")!))
+                            }
+                        }
+                        
+                        describe("when the additional path directory in caches exists") {
+                            beforeEach {
+                                fakeFileManager.stubbedFileExistsPath = true
+                                
+                                url = subject.buildFullFileURL(directory: .caches(), filename: "Goofus.json")
+                            }
+                            
+                            it("builds the correct URL") {
+                                expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                            }
+                        }
                     }
                     
-                    it("builds the correct URL") {
-                        expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                    describe("when NO additional path is given") {
+                        beforeEach {
+                            url = subject.buildFullFileURL(directory: .caches(), filename: "Goofus.json")
+                        }
+                        
+                        it("builds the correct URL") {
+                            expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                        }
                     }
                 }
                 
+                // Note: The "Library/Application Support" directory doesn't exist by default when an application is loaded.
+                // This is why we need code to create the directory to dump our logs in if it doesn't exist.
+                
+                // Additional note: The apple docs say that the directory is "Application support" with a lowercase "support".
+                // However, the FileManager API returns "Application Support" with an uppercase "Support".
+                
                 describe("when building '/Library/Application Support' directory URL") {
-                    // Note: The "Library/Application Support" directory doesn't exist by default when an application is loaded.
-                    // This is why we need code to create the directory to dump our logs in if it doesn't exist.
-                    
-                    // Additional note: The apple docs say that the directory is "Application support" with a lowercase "support".
-                    // However, the FileManager API returns "Application Support" with an uppercase "Support".
-                    
-                    describe("when the application support directory doesn't exist") {
-                        beforeEach {
-                            url = subject.buildFullFileURL(directory: .applicationSupport, filename: "Goofus.json")
-                        }
-                        
-                        it("creates the application support directory") {
-                            expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory"))
-                            expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory")))
-                            expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beFalsy())
-                            expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
-                        }
-                        
-                        it("builds the correct URL") {
-                            expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory"))
-                            expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory")!))
-                            expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beFalsy())
-                            expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                    describe("when an additional path is given") {
+                        describe("when the additional path directory in application support doesn't exist") {
+                            beforeEach {
+                                url = subject.buildFullFileURL(directory: .applicationSupport(path: "abc/123/"), filename: "Goofus.json")
+                            }
                             
-                            expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                            it("creates the application support directory") {
+                                expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory/abc/123"))
+                                expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/abc/123")))
+                                expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beTruthy())
+                                expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                            }
+                            
+                            it("builds the correct URL") {
+                                expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory/abc/123"))
+                                expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/abc/123")!))
+                                expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beTruthy())
+                                expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                                
+                                expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/abc/123/Goofus.json")!))
+                            }
+                        }
+                        
+                        describe("when the additional path directory in application support exists") {
+                            beforeEach {
+                                fakeFileManager.stubbedFileExistsPath = true
+                                
+                                url = subject.buildFullFileURL(directory: .applicationSupport(), filename: "Goofus.json")
+                            }
+                            
+                            it("builds the correct URL") {
+                                expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                            }
+                            
+                            it("can accept log saves") {
+                                expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory"))
+                                
+                                expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                            }
                         }
                     }
                     
-                    describe("when the application support directory exists") {
-                        beforeEach {
-                            fakeFileManager.stubbedFileExistsPath = true
+                    describe("when NO additional path is given") {
+                        describe("when the application support directory doesn't exist") {
+                            beforeEach {
+                                url = subject.buildFullFileURL(directory: .applicationSupport(), filename: "Goofus.json")
+                            }
                             
-                            url = subject.buildFullFileURL(directory: .applicationSupport, filename: "Goofus.json")
+                            it("creates the application support directory") {
+                                expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory"))
+                                expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory")))
+                                expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beTruthy())
+                                expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                            }
+                            
+                            it("builds the correct URL") {
+                                expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory"))
+                                expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///fake-directory/extra-fake-directory")!))
+                                expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beTruthy())
+                                expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
+                                
+                                expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                            }
                         }
                         
-                        it("builds the correct URL") {
-                            expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
-                        }
-                        
-                        it("can accept log saves") {
-                            expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory"))
+                        describe("when the application support directory exists") {
+                            beforeEach {
+                                fakeFileManager.stubbedFileExistsPath = true
+                                
+                                url = subject.buildFullFileURL(directory: .applicationSupport(), filename: "Goofus.json")
+                            }
                             
-                            expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                            it("builds the correct URL") {
+                                expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                            }
+                            
+                            it("can accept log saves") {
+                                expect(fakeFileManager.capturedFileExistsPath).to(equal("/fake-directory/extra-fake-directory"))
+                                
+                                expect(url).to(equal(URL(string: "file:///fake-directory/extra-fake-directory/Goofus.json")!))
+                            }
                         }
                     }
                 }
@@ -125,14 +321,14 @@ class FileUtilsSpec: QuickSpec {
                         it("creates the application support directory") {
                             expect(fakeFileManager.capturedFileExistsPath).to(equal("/whocares"))
                             expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///whocares")))
-                            expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beFalsy())
+                            expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beTruthy())
                             expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
                         }
                         
                         it("builds the correct URL") {
                             expect(fakeFileManager.capturedFileExistsPath).to(equal("/whocares"))
                             expect(fakeFileManager.capturedCreateDirectoryURL).to(equal(URL(string: "file:///whocares")!))
-                            expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beFalsy())
+                            expect(fakeFileManager.capturedCreateDirectoryCreateIntermediates).to(beTruthy())
                             expect(fakeFileManager.capturedCreateDirectoryAttributes).to(beNil())
                             
                             expect(url).to(equal(URL(string: "file:///whocares/Goofus.json")!))

--- a/Specs/QuickELoggerEngineSpec.swift
+++ b/Specs/QuickELoggerEngineSpec.swift
@@ -32,7 +32,7 @@ class QuickELoggerEngineSpec: QuickSpec {
             
             it("is setup properly") {
                 subject = QuickELoggerEngine(filename: "ItsLogLog",
-                                             directory: .documents,
+                                             directory: .documents(),
                                              fileManager: fakeFileManager,
                                              jsonEncoder: fakeJSONEncoder,
                                              jsonDecoder: fakeJSONDecoder,
@@ -41,7 +41,7 @@ class QuickELoggerEngineSpec: QuickSpec {
                                              uuid: fakeUUID)
                 
                 expect(subject.filename).to(equal("ItsLogLog.json"))
-                expect(subject.directory).to(equal(.documents))
+                expect(subject.directory).to(equal(.documents()))
                 expect(fakeJSONEncoder.capturedOutputFormatting).to(equal(.prettyPrinted))
                 expect(fakeJSONEncoder.capturedDateEncodingStrategy).to(equal(.iso8601))
                 
@@ -52,7 +52,7 @@ class QuickELoggerEngineSpec: QuickSpec {
             describe("logging a message") {
                 beforeEach {
                     subject = QuickELoggerEngine(filename: "ItsLogLog",
-                                                 directory: .documents,
+                                                 directory: .documents(),
                                                  fileManager: fakeFileManager,
                                                  jsonEncoder: fakeJSONEncoder,
                                                  jsonDecoder: fakeJSONDecoder,
@@ -76,7 +76,7 @@ class QuickELoggerEngineSpec: QuickSpec {
                         expect(fakeDataUtils.capturedWriteData).to(equal(fakeJSONEncoder.stubbedEncodeData))
                         expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "file:///fake-directory/fakefilename.json")))
                         
-                        expect(fakeFileUtils.capturedBuildFullFileURLDirectory).to(equal(.documents))
+                        expect(fakeFileUtils.capturedBuildFullFileURLDirectory).to(equal(.documents()))
                         expect(fakeFileUtils.capturedBuildFullFileURLFilename).to(equal("ItsLogLog.json"))
                     }
                 }
@@ -97,7 +97,7 @@ class QuickELoggerEngineSpec: QuickSpec {
                             expect(fakeDataUtils.capturedWriteData).to(equal(fakeJSONEncoder.stubbedEncodeData))
                             expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "file:///fake-directory/fakefilename.json")))
                             
-                            expect(fakeFileUtils.capturedBuildFullFileURLDirectory).to(equal(.documents))
+                            expect(fakeFileUtils.capturedBuildFullFileURLDirectory).to(equal(.documents()))
                             expect(fakeFileUtils.capturedBuildFullFileURLFilename).to(equal("ItsLogLog.json"))
                         }
                     }
@@ -119,7 +119,7 @@ class QuickELoggerEngineSpec: QuickSpec {
                             expect(fakeDataUtils.capturedWriteData).to(equal(fakeJSONEncoder.stubbedEncodeData))
                             expect(fakeDataUtils.capturedWriteURL).to(equal(URL(string: "file:///fake-directory/fakefilename.json")))
                             
-                            expect(fakeFileUtils.capturedBuildFullFileURLDirectory).to(equal(.documents))
+                            expect(fakeFileUtils.capturedBuildFullFileURLDirectory).to(equal(.documents()))
                             expect(fakeFileUtils.capturedBuildFullFileURLFilename).to(equal("ItsLogLog.json"))
                         }
                     }


### PR DESCRIPTION
Using fancy Swift `enums` with associated values, a user can now enter additional path information when creating an instance of the logger.

For example, instead of saving directly to the `.documents` directory, a user can now save to a sub directory in the documents directory: `.documents(path: "yep/sure/")` which will save in `/Documents/yep/sure/`


* Update `.swiftlint`
* Add more integration specs
* Update `FileManagerUtils` in the integration specs target to delete directories as well as files