### PR TITLE
Change default dir

### DIFF
--- a/IntegrationSpecs/QuickELoggerObjCIntegrationSpec.swift
+++ b/IntegrationSpecs/QuickELoggerObjCIntegrationSpec.swift
@@ -8,6 +8,8 @@ class QuickELoggerObjCIntegrationSpec: QuickSpec {
         describe("QuickELoggerObjC") {
             var subject: QuickELoggerObjC!
             
+            // Mas cleanup...
+            
             beforeSuite {
                 deleteTestArtifacts()
             }

--- a/IntegrationSpecs/Utils/Utils.swift
+++ b/IntegrationSpecs/Utils/Utils.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import QuickELogger
 
-func getLogMessages(filename: String = "QuickELogger", directory: Directory = .documents()) -> [LogMessage] {    
+func getLogMessages(filename: String = "QuickELogger", directory: Directory = .applicationSupport(path: "QuickELogger/")) -> [LogMessage] {
     let fullFilename = filename + ".json"
     
     let fullPathOfJSONFile = FileUtils().buildFullFileURL(directory: directory,

--- a/QuickELogger/Source/ObjC/QuickELoggerObjC.swift
+++ b/QuickELogger/Source/ObjC/QuickELoggerObjC.swift
@@ -66,14 +66,14 @@ public class QuickELoggerObjC: NSObject {
     
     @objc
     public convenience override init() {
-        let defaultDirectoryInfo = ObjCDirectoryInfo(directory: .documents, additionalPath: nil)
+        let defaultDirectoryInfo = ObjCDirectoryInfo(directory: .applicationSupport, additionalPath: "QuickELogger/")
         
         self.init(filename: "QuickELogger", directoryInfo: defaultDirectoryInfo)
     }
     
     @objc
     public convenience init(filename: String) {
-        let defaultDirectoryInfo = ObjCDirectoryInfo(directory: .documents, additionalPath: nil)
+        let defaultDirectoryInfo = ObjCDirectoryInfo(directory: .applicationSupport, additionalPath: "QuickELogger/")
         
         self.init(filename: filename, directoryInfo: defaultDirectoryInfo)
     }

--- a/QuickELogger/Source/Swift/QuickELogger.swift
+++ b/QuickELogger/Source/Swift/QuickELogger.swift
@@ -54,7 +54,7 @@ public class QuickELogger: NSObject, QuickELoggerProtocol {
     
     // MARK: - Init methods
     
-    public init(filename: String = "QuickELogger", directory: Directory = .documents()) {
+    public init(filename: String = "QuickELogger", directory: Directory = .applicationSupport(path: "QuickELogger/")) {
         self.filename = filename
         self.directory = directory
         

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A quick and simple way to log messages to disk on your iPhone or iPad app.
 * Objective-C -> Create an instance of `QuickELoggerObjC`, and calling `logWithMessage:type:`
 * This logger has the following (pretty standard) log types: `verbose, info, debug, warn, error`.
 
-Note: By default the file is saved in the `/Documents` directory with the filename `QuickELogger.json`.
+Note: By default the file is saved in the `/Library/Application Support/QuickELogger/` directory with the filename `QuickELogger.json`.
 
 ### Additional configuration options
 


### PR DESCRIPTION
[After reading the following Apple File System Basics article,](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html) I felt like it's better to make the default location of this logger to be in the `/Library/Application Support/QuickELogger` directory instead of `/Documents`.

This will require a minor bump in the version number of the Cocoapod.